### PR TITLE
Restore central directory buffering

### DIFF
--- a/src/base/read/mod.rs
+++ b/src/base/read/mod.rs
@@ -35,7 +35,10 @@ use crate::string::StringEncoding;
 use crate::base::read::io::CombinedCentralDirectoryRecord;
 use crate::spec::parse::parse_extra_fields;
 
-use futures_lite::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, SeekFrom};
+use futures_lite::io::{AsyncBufRead, AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, BufReader, SeekFrom};
+
+/// The max buffer size used when parsing the central directory, equal to 20MiB.
+const MAX_CD_BUFFER_SIZE: usize = 20 * 1024 * 1024;
 
 pub(crate) async fn file<R>(mut reader: R) -> Result<ZipFile>
 where
@@ -77,7 +80,12 @@ where
 
     // Find and parse the central directory.
     reader.seek(SeekFrom::Start(eocdr.offset_of_start_of_directory)).await?;
-    let entries = crate::base::read::cd(reader, eocdr.num_entries_in_directory, zip64).await?;
+
+    // To avoid lots of small reads to `reader` when parsing the central directory, we use a BufReader that can read the whole central directory at once.
+    // Because `eocdr.offset_of_start_of_directory` is a u64, we use MAX_CD_BUFFER_SIZE to prevent very large buffer sizes.
+    let buf =
+        BufReader::with_capacity(std::cmp::min(eocdr.offset_of_start_of_directory as _, MAX_CD_BUFFER_SIZE), reader);
+    let entries = crate::base::read::cd(buf, eocdr.num_entries_in_directory, zip64).await?;
 
     Ok(ZipFile { entries, comment, zip64 })
 }


### PR DESCRIPTION
## Summary

This was removed in https://github.com/Majored/rs-async-zip/commit/32cd802eb2af6611cc5bb2e5b82dcd78a9920b0e, but it's actually really important for our use-case, because we want to read the central directory in one shot in `wheel_metadata_from_remote_zip`.

An alternative solution would be...

- Return some other struct from `file`, that includes `eocdr`, `comment`, `zip64`.
- Outside of the crate, prefetch the buffer in one shot (or wrap in a new buffered reader with the exact capacity we want).
- Pass the constructed file into `ZipFileReader::from_raw_parts`.

But this is a little easier.
