### PR TITLE
Stop reading central directory at ZIP64 EOCDR signature

### DIFF
--- a/src/base/read/cd.rs
+++ b/src/base/read/cd.rs
@@ -2,7 +2,7 @@ use futures_lite::io::{AsyncRead, AsyncReadExt};
 
 use crate::base::read::{detect_filename, io};
 use crate::error::{Result, ZipError};
-use crate::spec::consts::{CDH_SIGNATURE, EOCDR_SIGNATURE};
+use crate::spec::consts::{CDH_SIGNATURE, EOCDR_SIGNATURE, ZIP64_EOCDR_SIGNATURE};
 use crate::spec::header::CentralDirectoryRecord;
 use crate::spec::parse::parse_extra_fields;
 use crate::ZipString;
@@ -69,6 +69,7 @@ where
             match signature {
                 CDH_SIGNATURE => (),
                 EOCDR_SIGNATURE => return Ok(None),
+                ZIP64_EOCDR_SIGNATURE => return Ok(None),
                 actual => return Err(ZipError::UnexpectedHeaderError(actual, CDH_SIGNATURE)),
             }
         }


### PR DESCRIPTION
## Summary

The `CentralDirectoryReader` doesn't actually use the end-of-central-directory record -- we just use the central directory _entries_. So from the perspective of the reader, it should be equally fine to stop at the ZIP64 EOCDR signature (which should be followed by the ZIP64 EOCDR, then the ZIP64 locator, then the EOCDR).
