### PR TITLE
Expose file offsets in streaming iterators

### DIFF
--- a/src/base/read/cd.rs
+++ b/src/base/read/cd.rs
@@ -33,6 +33,11 @@ impl CentralDirectoryEntry {
     pub fn unix_permissions(&self) -> Option<u32> {
         Some((self.header.exter_attr) >> 16)
     }
+
+    /// Returns the file offset of the entry in the ZIP file.
+    pub fn file_offset(&self) -> u32 {
+        self.header.lh_offset
+    }
 }
 
 #[derive(Clone)]

--- a/src/base/read/mod.rs
+++ b/src/base/read/mod.rs
@@ -199,12 +199,13 @@ where
         extra_fields,
         comment,
         data_descriptor: header.flags.data_descriptor,
+        file_offset,
     };
 
     Ok(StoredZipEntry { entry, file_offset, header_size: header_size + trailing_size })
 }
 
-pub(crate) async fn lfh<R>(mut reader: R) -> Result<Option<ZipEntry>>
+pub(crate) async fn lfh<R>(mut reader: R, file_offset: u64) -> Result<Option<ZipEntry>>
 where
     R: AsyncRead + Unpin,
 {
@@ -263,6 +264,7 @@ where
         extra_fields,
         comment: String::new().into(),
         data_descriptor: header.flags.data_descriptor,
+        file_offset,
     };
 
     Ok(Some(entry))

--- a/src/base/read/stream.rs
+++ b/src/base/read/stream.rs
@@ -49,6 +49,10 @@
 use crate::base::read::io::entry::ZipEntryReader;
 use crate::error::Result;
 use crate::error::ZipError;
+use std::io;
+use std::io::Read;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 use crate::spec::consts::DATA_DESCRIPTOR_LENGTH;
 use crate::spec::consts::DATA_DESCRIPTOR_SIGNATURE;
@@ -57,13 +61,71 @@ use crate::spec::consts::SIGNATURE_LENGTH;
 use crate::tokio::read::stream::Ready as TokioReady;
 
 use futures_lite::io::AsyncBufRead;
+use futures_lite::io::AsyncRead;
 use futures_lite::io::AsyncReadExt;
-
-#[cfg(feature = "tokio")]
-use tokio_util::compat::TokioAsyncReadCompatExt;
 
 use super::io::entry::WithEntry;
 use super::io::entry::WithoutEntry;
+#[cfg(feature = "tokio")]
+use tokio_util::compat::TokioAsyncReadCompatExt;
+
+/// A wrapper around a reader that counts the number of bytes read.
+pub struct Counting<R> {
+    inner: R,
+    bytes: u64,
+}
+
+impl<R> Counting<R> {
+    /// Creates a new [`Counting`] reader that wraps the provided inner reader.
+    pub fn new(inner: R) -> Self {
+        Self { inner, bytes: 0 }
+    }
+
+    /// Returns the number of bytes read so far.
+    pub fn bytes_read(&self) -> u64 {
+        self.bytes
+    }
+
+    /// Consumes the [`Counting`] reader and returns the inner reader.
+    pub fn into_inner(self) -> R {
+        self.inner
+    }
+}
+
+impl<R: Read> Read for Counting<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        self.bytes += n as u64;
+        Ok(n)
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for Counting<R> {
+    fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+
+        match Pin::new(&mut this.inner).poll_read(cx, buf) {
+            Poll::Ready(Ok(n)) => {
+                this.bytes += n as u64;
+                Poll::Ready(Ok(n))
+            }
+            other => other,
+        }
+    }
+}
+
+impl<R: AsyncBufRead + Unpin> AsyncBufRead for Counting<R> {
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.inner).poll_fill_buf(cx)
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        let this = self.get_mut();
+        this.bytes += amt as u64;
+        Pin::new(&mut this.inner).consume(amt);
+    }
+}
 
 /// A type which encodes that [`ZipFileReader`] is ready to open a new entry.
 pub struct Ready<R>(R);
@@ -77,18 +139,19 @@ pub struct Reading<'a, R, E>(ZipEntryReader<'a, R, E>, bool);
 #[derive(Clone)]
 pub struct ZipFileReader<S>(S);
 
-impl<'a, R> ZipFileReader<Ready<R>>
+impl<'a, R> ZipFileReader<Ready<Counting<R>>>
 where
     R: AsyncBufRead + Unpin + 'a,
 {
     /// Constructs a new ZIP reader from a non-seekable source.
     pub fn new(reader: R) -> Self {
-        Self(Ready(reader))
+        Self(Ready(Counting::new(reader)))
     }
 
     /// Opens the next entry for reading if the central directory hasn’t yet been reached.
-    pub async fn next_without_entry(mut self) -> Result<Option<ZipFileReader<Reading<'a, R, WithoutEntry>>>> {
-        let entry = match crate::base::read::lfh(&mut self.0 .0).await? {
+    pub async fn next_without_entry(mut self) -> Result<Option<ZipFileReader<Reading<'a, Counting<R>, WithoutEntry>>>> {
+        let file_offset = self.0 .0.bytes_read();
+        let entry = match crate::base::read::lfh(&mut self.0 .0, file_offset).await? {
             Some(entry) => entry,
             None => return Ok(None),
         };
@@ -100,8 +163,9 @@ where
     }
 
     /// Opens the next entry for reading if the central directory hasn’t yet been reached.
-    pub async fn next_with_entry(mut self) -> Result<Option<ZipFileReader<Reading<'a, R, WithEntry<'a>>>>> {
-        let entry = match crate::base::read::lfh(&mut self.0 .0).await? {
+    pub async fn next_with_entry(mut self) -> Result<Option<ZipFileReader<Reading<'a, Counting<R>, WithEntry<'a>>>>> {
+        let file_offset = self.0 .0.bytes_read();
+        let entry = match crate::base::read::lfh(&mut self.0 .0, file_offset).await? {
             Some(entry) => entry,
             None => return Ok(None),
         };
@@ -115,7 +179,7 @@ where
 
     /// Consumes the `ZipFileReader` returning the original `reader`
     pub async fn into_inner(self) -> R {
-        self.0 .0
+        self.0 .0.into_inner()
     }
 }
 

--- a/src/entry/mod.rs
+++ b/src/entry/mod.rs
@@ -45,6 +45,7 @@ pub struct ZipEntry {
     pub(crate) extra_fields: Vec<ExtraField>,
     pub(crate) comment: ZipString,
     pub(crate) data_descriptor: bool,
+    pub(crate) file_offset: u64,
 }
 
 impl From<ZipEntryBuilder> for ZipEntry {
@@ -77,6 +78,7 @@ impl ZipEntry {
             extra_fields: Vec::new(),
             comment: String::new().into(),
             data_descriptor: false,
+            file_offset: 0,
         }
     }
 
@@ -155,6 +157,11 @@ impl ZipEntry {
     /// Returns whether or not the entry represents a directory.
     pub fn dir(&self) -> Result<bool> {
         Ok(self.filename.as_str()?.ends_with('/'))
+    }
+
+    /// Returns the file offset in bytes of the local file header for this entry.
+    pub fn file_offset(&self) -> u64 {
+        self.file_offset
     }
 }
 


### PR DESCRIPTION
## Summary

Allows streaming use-cases to read the offset at which each local header is written.